### PR TITLE
Enable sensorhub-driver-template by default in test module, add and clarify comments

### DIFF
--- a/tools/sensorhub-test/build.gradle
+++ b/tools/sensorhub-test/build.gradle
@@ -3,23 +3,22 @@ description = 'Main Test Project'
 targetCompatibility = 11
 
 dependencies {
-  implementation 'org.sensorhub:sensorhub-core:' + oshCoreVersion
-  implementation 'org.sensorhub:sensorhub-core-osgi:' + oshCoreVersion
-  implementation 'org.sensorhub:sensorhub-datastore-h2:' + oshCoreVersion
-  implementation 'org.sensorhub:sensorhub-service-swe:' + oshCoreVersion
-  implementation 'org.sensorhub:sensorhub-webui-core:' + oshCoreVersion
-  implementation 'org.sensorhub:sensorhub-service-consys:' + oshCoreVersion
+    implementation 'org.sensorhub:sensorhub-core:' + oshCoreVersion
+    implementation 'org.sensorhub:sensorhub-datastore-h2:' + oshCoreVersion
+    implementation 'org.sensorhub:sensorhub-webui-core:' + oshCoreVersion
+    implementation 'org.sensorhub:sensorhub-service-consys:' + oshCoreVersion
+    implementation project(':sensorhub-driver-template')
 
-  // To test your own modules copy the template and set the project name to your modules project name.
-  // You must make sure that your project is enabled by including it in the settings.gradle file.
-  //
-  // !!!!!
-  // Do not include this "sensorhub-test" project in build.gradle as it will be packaged with your
-  // build if you do
-  // !!!!!
-  //
-  // implementation project(':PROJECT_NAME')
-  //
-  // EX:
-  // implementation project(':sensorhub-driver-rtpcam')
+    // To test your own modules copy the template and set the project name to your modules project name.
+    // You must make sure that your project is enabled by including it in the settings.gradle file.
+    //
+    // !!!!!
+    // Do not include this "sensorhub-test" project in build.gradle as it will be packaged with your
+    // build if you do
+    // !!!!!
+    //
+    // implementation project(':PROJECT_NAME')
+    //
+    // EX:
+    // implementation project(':sensorhub-driver-rtpcam')
 }

--- a/tools/sensorhub-test/build.gradle
+++ b/tools/sensorhub-test/build.gradle
@@ -9,16 +9,10 @@ dependencies {
     implementation 'org.sensorhub:sensorhub-service-consys:' + oshCoreVersion
     implementation project(':sensorhub-driver-template')
 
-    // To test your own modules copy the template and set the project name to your modules project name.
-    // You must make sure that your project is enabled by including it in the settings.gradle file.
-    //
-    // !!!!!
-    // Do not include this "sensorhub-test" project in build.gradle as it will be packaged with your
-    // build if you do
-    // !!!!!
-    //
-    // implementation project(':PROJECT_NAME')
-    //
+    // To test your own modules, add a line with your module's project name.
     // EX:
     // implementation project(':sensorhub-driver-rtpcam')
+
+    // You must make sure that your project is enabled by including it in the settings.gradle file.
+    // Do not include this "sensorhub-test" project in build.gradle as it will be packaged with your build if you do!
 }

--- a/tools/sensorhub-test/src/main/java/org/sensorhub/node/test/TestSensorHub.java
+++ b/tools/sensorhub-test/src/main/java/org/sensorhub/node/test/TestSensorHub.java
@@ -13,11 +13,24 @@ package org.sensorhub.node.test;
 
 import org.sensorhub.impl.SensorHub;
 
+/**
+ * The sensorhub-test module provides a convenient way to build and run an OpenSensorHub (OSH) node
+ * without requiring a full build, extraction, and launch process.
+ * This allows developers to set breakpoints in the IDE and debug the drivers directly.
+ * <p>
+ * Running this class will launch an OSH node on the address and port and with the credentials
+ * specified in the config.json file.
+ * By default, the OSH admin panel can be accessed via the web interface at localhost:8282/sensorhub/admin
+ * with the default credentials admin/admin.
+ * The API can be accessed at localhost:8282/sensorhub/api.
+ * <p>
+ * Additional drivers can be added to the build.gradle file in the dependencies section.
+ */
 public class TestSensorHub {
     private TestSensorHub() {
     }
 
-    public static void main(String[] args) throws Exception {
+    public static void main(String[] args) {
         SensorHub.main(new String[]{"tools/sensorhub-test/src/main/resources/config.json", "storage"});
     }
 }


### PR DESCRIPTION
I changed it so that the sensorhub-driver-template driver is now enabled by default in the sensorhub-test module, just like we did with the main module a while back. Now it can be run without any need for configuration so that developers have a functional example to work with.

I also added comments explaining the purpose of the sensorhub-test module and how to use it, as well as clarified the comment in the build.gradle.